### PR TITLE
Add fnv1a_h.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ endif
 override LIBS += $(SOCKET_LIBS) -pthread
 
 OBJS = \
+	fnv1a.o \
 	relay.o \
 	md5.o \
 	consistent-hash.o \

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The route file syntax is as follows:
 # comments are allowed in any place and start with a hash (#)
 
 cluster <name>
-    <forward | any_of [useall] | failover | <carbon_ch | fnv1a_ch> [replication <count>]>
+    <forward | any_of [useall] | failover | fnv1a_h | <carbon_ch | fnv1a_ch> [replication <count>]>
         <host[:port][=instance] [proto <udp | tcp>]> ...
     ;
 cluster <name>

--- a/aggregator.c
+++ b/aggregator.c
@@ -24,6 +24,7 @@
 #include <pthread.h>
 #include <assert.h>
 
+#include "fnv1a.h"
 #include "relay.h"
 #include "dispatcher.h"
 #include "server.h"
@@ -142,7 +143,6 @@ aggregator_putmetric(
 	char *newfirstspace = NULL;
 	size_t len;
 	const char *ometric;
-	const char *omp;
 	unsigned int omhash;
 	unsigned int omhtbucket;
 	struct _aggr_computes *compute;
@@ -179,10 +179,7 @@ aggregator_putmetric(
 			ometric = newmetric;
 		}
 
-		omhash = 2166136261UL;  /* FNV1a */
-		for (omp = ometric; *omp != '\0'; omp++)
-			omhash = (omhash ^ (unsigned int)*omp) * 16777619;
-
+		omhash = fnv1a_hash32(ometric, ometric + strlen(ometric));
 		omhtbucket =
 			((omhash >> AGGR_HT_POW_SIZE) ^ omhash) &
 			(((unsigned int)1 << AGGR_HT_POW_SIZE) - 1);

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -247,7 +247,7 @@ int
 dispatch_addlistener_udp(int sock)
 {
 	int conn = dispatch_addconnection(sock);
-	
+
 	if (conn == -1)
 		return 1;
 
@@ -328,9 +328,9 @@ dispatch_connection(connection *conn, dispatcher *self)
 	/* try to read more data, if that succeeds, or we still have data
 	 * left in the buffer, try to process the buffer */
 	if (
-			(!conn->needmore && conn->buflen > 0) || 
+			(!conn->needmore && conn->buflen > 0) ||
 			(len = read(conn->sock,
-						conn->buf + conn->buflen, 
+						conn->buf + conn->buflen,
 						(sizeof(conn->buf) - 1) - conn->buflen)) > 0
 	   )
 	{

--- a/fnv1a.c
+++ b/fnv1a.c
@@ -1,0 +1,29 @@
+#include "fnv1a.h"
+
+#define FNV_32_PRIME 0x01000193U
+#define FNV_32_INIT 0x811c9dc5U
+
+/**
+ * Computes the hash for key in a 32-bit unsigned integer space.
+ **/
+unsigned int
+fnv1a_hash32(const char *key, const char *end)
+{
+	unsigned int hash = FNV_32_INIT;
+	for (; key < end; key++)
+		hash = (hash ^ (unsigned char)*key) * FNV_32_PRIME;
+	return hash;
+}
+
+/**
+ * Computes the hash position for key in a 16-bit unsigned integer
+ * space.  Returns a number between 0 and 65535 based on the FNV1a hash
+ * algorithm.
+ */
+unsigned short
+fnv1a_hash16(const char *key, const char *end)
+{
+	unsigned int hash = fnv1a_hash32(key, end);
+	return (unsigned short)((hash >> 16) ^ (hash & (unsigned short)0xFFFF));
+}
+

--- a/fnv1a.h
+++ b/fnv1a.h
@@ -1,5 +1,5 @@
-#ifndef FNV1A_H
-#define FNV1A_H 1
+#ifndef __FNV1A_H__
+#define __FNV1A_H__ 1
 
 unsigned int fnv1a_hash32(const char *key, const char *end);
 unsigned short fnv1a_hash16(const char *key, const char *end);

--- a/fnv1a.h
+++ b/fnv1a.h
@@ -1,0 +1,7 @@
+#ifndef FNV1A_H
+#define FNV1A_H 1
+
+unsigned int fnv1a_hash32(const char *key, const char *end);
+unsigned short fnv1a_hash16(const char *key, const char *end);
+
+#endif

--- a/server.c
+++ b/server.c
@@ -39,6 +39,7 @@ struct _server {
 	const char *ip;
 	unsigned short port;
 	char *instance;
+	int group_id;  /* Used when cl->type == FNV1A_H */
 	struct addrinfo *saddr;
 	int fd;
 	queue *queue;
@@ -473,12 +474,23 @@ server_set_failover(server *self)
 }
 
 /**
- * Sets instance name only used for carbon_ch cluster type.
+ * Sets instance name used for <carbon_ch|fnv1a_ch|fnv1a_h> cluster type.
  */
 void
 server_set_instance(server *self, char *instance)
 {
 	self->instance = strdup(instance);
+}
+
+/**
+ * Sets group_id only used for fnv1a_h cluster type.
+ */
+int
+server_set_group_id(server *self)
+{
+	char *endp = NULL;
+	self->group_id = strtol(self->instance, &endp, 10);
+	return *endp == '\0';
 }
 
 /**
@@ -537,7 +549,7 @@ server_shutdown(server *s)
 	size_t failures;
 	size_t inqueue;
 	int err;
-	
+
 	if (s->tid == 0)
 		return;
 
@@ -622,6 +634,14 @@ inline char *
 server_instance(server *s)
 {
 	return s->instance;
+}
+
+/**
+ * Returns the group_id associated with this server.
+ */
+int
+server_group_id(server *s) {
+	return s->group_id;
 }
 
 /**

--- a/server.h
+++ b/server.h
@@ -34,12 +34,14 @@ server *server_new(
 void server_add_secondaries(server *d, server **sec, size_t cnt);
 void server_set_failover(server *d);
 void server_set_instance(server *d, char *inst);
+int server_set_group_id(server *d);
 char server_send(server *s, const char *d, char force);
 void server_stop(server *s);
 void server_shutdown(server *s);
 const char *server_ip(server *s);
 unsigned short server_port(server *s);
 char *server_instance(server *s);
+int server_group_id(server *s);
 serv_ctype server_ctype(server *s);
 char server_failed(server *s);
 size_t server_get_ticks(server *s);


### PR DESCRIPTION
Following is an example configuration.

```
   cluster dc
        fnv1a_h
            127.0.0.1:2103=0
            127.0.0.1:2203=0
            127.0.0.1:2303=1
            127.0.0.1:2403=1
        ;

    match *
        send to dc
        ;
```

The number after `=` is group index.

When the cluster `dc` receive a metric
1. Compute the hash value, h = fnv1a(metric_name)
2. Compute the index of group, idx = h % <number of groups>
3. Send metric to all instances in the group.

refer issue: https://github.com/grobian/carbon-c-relay/issues/108
