### PR TITLE
Ensure metrics reported by relay are not cumulative.

### DIFF
--- a/dispatcher.c
+++ b/dispatcher.c
@@ -657,7 +657,9 @@ dispatch_reloadcomplete(dispatcher *d)
 inline size_t
 dispatch_get_ticks(dispatcher *self)
 {
-	return self->ticks;
+	size_t val = self->ticks;
+	self->ticks = 0;
+	return val;
 }
 
 /**
@@ -666,7 +668,9 @@ dispatch_get_ticks(dispatcher *self)
 inline size_t
 dispatch_get_metrics(dispatcher *self)
 {
-	return self->metrics;
+	size_t val = self->metrics;
+	self->metrics = 0;
+	return val;
 }
 
 /**

--- a/server.c
+++ b/server.c
@@ -674,7 +674,9 @@ server_get_ticks(server *s)
 {
 	if (s == NULL)
 		return 0;
-	return s->ticks;
+	size_t val = s->ticks;
+	s->ticks = 0;
+	return val;
 }
 
 /**
@@ -685,7 +687,9 @@ server_get_metrics(server *s)
 {
 	if (s == NULL)
 		return 0;
-	return s->metrics;
+	size_t val = s->metrics;
+	s->metrics = 0;
+	return val;
 }
 
 /**
@@ -696,7 +700,9 @@ server_get_dropped(server *s)
 {
 	if (s == NULL)
 		return 0;
-	return s->dropped;
+	size_t val = s->dropped;
+	s->dropped = 0;
+	return val;
 }
 
 /**
@@ -709,7 +715,9 @@ server_get_stalls(server *s)
 {
 	if (s == NULL)
 		return 0;
-	return s->stalls;
+	size_t val = s->stalls;
+	s->stalls = 0;
+	return val;
 }
 
 /**


### PR DESCRIPTION
Since the metrics / dropped / etc counters are only used by the
collector, it should be okay to reset them after use. This should make
these carbon.relay.\* metrics equivalent to the ones in the original
python daemon.

refer: https://github.com/grobian/carbon-c-relay/pull/89
