### PR TITLE
router: Add FNV1A_SH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The route file syntax is as follows:
 # comments are allowed in any place and start with a hash (#)
 
 cluster <name>
-    <forward | any_of [useall] | failover | fnv1a_h | <carbon_ch | fnv1a_ch> [replication <count>]>
+    <forward | any_of [useall] | failover | fnv1a_h | fnv1a_sh | <carbon_ch | fnv1a_ch> [replication <count>]>
         <host[:port][=instance] [proto <udp | tcp>]> ...
     ;
 cluster <name>

--- a/fnv1a.c
+++ b/fnv1a.c
@@ -15,6 +15,16 @@ fnv1a_hash32(const char *key, const char *end)
 	return hash;
 }
 
+
+/**
+ * Computes the hash for key in a 32-bit signed integer space.
+ */
+int
+fnv1a_signed_hash32(const char *key, const char *end) {
+    return (int)fnv1a_hash32(key, end);
+}
+
+
 /**
  * Computes the hash position for key in a 16-bit unsigned integer
  * space.  Returns a number between 0 and 65535 based on the FNV1a hash

--- a/fnv1a.h
+++ b/fnv1a.h
@@ -2,6 +2,7 @@
 #define __FNV1A_H__ 1
 
 unsigned int fnv1a_hash32(const char *key, const char *end);
+int fnv1a_signed_hash32(const char *key, const char *end);
 unsigned short fnv1a_hash16(const char *key, const char *end);
 
 #endif

--- a/server.c
+++ b/server.c
@@ -39,7 +39,7 @@ struct _server {
 	const char *ip;
 	unsigned short port;
 	char *instance;
-	int group_id;  /* Used when cl->type == FNV1A_H */
+	int group_id;  /* Used when cl->type in (FNV1A_H, FNV1A_SH) */
 	struct addrinfo *saddr;
 	int fd;
 	queue *queue;
@@ -474,7 +474,7 @@ server_set_failover(server *self)
 }
 
 /**
- * Sets instance name used for <carbon_ch|fnv1a_ch|fnv1a_h> cluster type.
+ * Sets instance name used for <carbon_ch|fnv1a_ch|fnv1a_h|fnv1a_sh> cluster type.
  */
 void
 server_set_instance(server *self, char *instance)
@@ -483,7 +483,7 @@ server_set_instance(server *self, char *instance)
 }
 
 /**
- * Sets group_id only used for fnv1a_h cluster type.
+ * Sets group_id used for <fnv1a_h|fnv1a_sh> cluster type.
  */
 int
 server_set_group_id(server *self)


### PR DESCRIPTION
The reason we provide FNV1A_SH (SH means Signed Hash) is that our internal
Python implementation of `fvn1a.get_hash_bugfree` is a signed integer
function, and I have used it in carbon-relay. If you don't have this
problem, just use FNV1A_H.
